### PR TITLE
sortEvents missing a return when comparing AnyOf and UnicodeClass

### DIFF
--- a/lex/items/event/event.go
+++ b/lex/items/event/event.go
@@ -194,7 +194,7 @@ func sortEvents(events []ast.LexBase) {
 			case *ast.Not:
 				return e1.Set.Subset(e2.Set)
 			case *ast.UnicodeClass:
-				unicodeClassContains(e2, e1.Set.Elements()...)
+				return unicodeClassContains(e2, e1.Set.Elements()...)
 			default:
 				panic("Invalid")
 			}


### PR DESCRIPTION
Hi,

This MR addresses the following panic encountered when using the below grammar.

```
panic: Missing return

goroutine 1 [running]:
github.com/goccmack/gogll/lex/items/event.sortEvents.func1(0xa, 0x9, 0x609200)
        /home/paul/src/github.com/goccmack/gogll/lex/items/event/event.go:249 +0x66f
sort.insertionSort_func(0xc0001c7ac8, 0xc0001e13e0, 0x0, 0xb)
        /home/paul/.opt/go/src/sort/zfuncversion.go:12 +0xab
sort.quickSort_func(0xc0001c7ac8, 0xc0001e13e0, 0x0, 0xb, 0x8)
        /home/paul/.opt/go/src/sort/zfuncversion.go:158 +0x1f6
sort.Slice(0x5ef2e0, 0xc00000c9c0, 0xc0001c7ac8)
        /home/paul/.opt/go/src/sort/slice.go:20 +0xe8
github.com/goccmack/gogll/lex/items/event.sortEvents(0xc00014c300, 0xb, 0x10)
        /home/paul/src/github.com/goccmack/gogll/lex/items/event/event.go:182 +0xa5
github.com/goccmack/gogll/lex/items/event.GetOrdered(0xc0000622a0, 0xb, 0xb, 0xb, 0x8, 0xc00000f0f0)
        /home/paul/src/github.com/goccmack/gogll/lex/items/event/event.go:70 +0x30d
github.com/goccmack/gogll/lex/items.(*Set).nextSets(0xc00012ae00, 0x0, 0x0, 0x0)
        /home/paul/src/github.com/goccmack/gogll/lex/items/items.go:174 +0x67
github.com/goccmack/gogll/lex/items.New(0xc00006c280, 0xc00000c5e8)
        /home/paul/src/github.com/goccmack/gogll/lex/items/items.go:65 +0x24c
main.main()
        /home/paul/src/github.com/goccmack/gogll/main.go:84 +0x21c
```

```
package "github.com/goccmack/gogll/temp"

Block
    : Statement
    | Statement ";" Block
    | empty
    ;

identifier : < letter | '_' > { < letter | number | '_' > } ;
integer_lit : [ '-' ] ( (any "123456789") { (any "0123456789") } | '0' ) ;

Statement : PrintStmt
          | AssignmentStmt
          ;

PrintStmt : "print" "(" integer_lit ")" ;
AssignmentStmt : identifier "=" integer_lit ;
```