### PR TITLE
vet fixes: general go vet fixes. fix lr1/firsts test to use up to date parser api

### DIFF
--- a/ast/lex.go
+++ b/ast/lex.go
@@ -469,7 +469,7 @@ func (u UnicodeRanges) String() string {
 		if rng.Exclude {
 			fmt.Fprint(w, "-")
 		}
-		fmt.Fprint(w, "\\p{%s}", rng)
+		fmt.Fprintf(w, "\\p{%s}", rng)
 	}
 	return w.String()
 }

--- a/gen/golang/gll/parser.go
+++ b/gen/golang/gll/parser.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"os"
 	"path"
 	"path/filepath"
 	"text/template"
@@ -94,7 +93,6 @@ func (g *gen) getData(baseDir string) *Data {
 func parseErrorError(err error) {
 	fmt.Printf("Error generating parser: %s\n", err)
 	panic("fix me")
-	os.Exit(1)
 }
 
 const mainTemplate = `

--- a/lex/item/item_test.go
+++ b/lex/item/item_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/goccmack/gogll/v3/lex/item/pos"
 	"github.com/goccmack/gogll/v3/lexer"
 	"github.com/goccmack/gogll/v3/parser"
-	"github.com/goccmack/gogll/v3/parser/bsr"
 )
 
 const src = `package "names"
@@ -17,8 +16,14 @@ qualifiedName : letter {letter|number|'_'} <'.' <letter|number|'_'>> ;
 
 func Test1(t *testing.T) {
 	lex := lexer.New([]rune(src))
-	parser.Parse(lex)
-	g := ast.Build(bsr.GetRoot(), lex)
+	bsr, err := parser.Parse(lex)
+	if err != nil {
+		for _, e := range err {
+			fmt.Printf("error: %#v\n", e.String())
+		}
+		panic(err)
+	}
+	g := ast.Build(bsr.GetRoot(), lex, "test.md")
 
 	it := &Item{g.LexRules[0], pos.From([]int{2, 0, 1, 0, 1})}
 	// it := &Item{g.LexRules[0], pos.From([]int{2, 0, 2})}

--- a/lex/items/event/event.go
+++ b/lex/items/event/event.go
@@ -298,7 +298,6 @@ func sortEvents(events []ast.LexBase) {
 		default:
 			panic("Invalid")
 		}
-		panic("Missing return")
 	})
 }
 

--- a/lex/items/items.go
+++ b/lex/items/items.go
@@ -261,11 +261,11 @@ func (sets *Sets) add(set *Set) *Sets {
 }
 
 func stringLitToRule(sl *ast.StringLit) *ast.LexRule {
-	return &ast.LexRule{false, ast.StringLitToTokID(sl), stringLitToRegExp(sl)}
+	return &ast.LexRule{Suppress: false, TokID: ast.StringLitToTokID(sl), RegExp: stringLitToRegExp(sl)}
 }
 
 func stringLitToRegExp(sl *ast.StringLit) *ast.RegExp {
-	return &ast.RegExp{stringLitToLexSymbols(sl)}
+	return &ast.RegExp{Symbols: stringLitToLexSymbols(sl)}
 }
 
 func stringLitToLexSymbols(sl *ast.StringLit) (symbols []ast.LexSymbol) {

--- a/lex/items/items_test.go
+++ b/lex/items/items_test.go
@@ -1,12 +1,12 @@
 package items
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/goccmack/gogll/v3/ast"
 	"github.com/goccmack/gogll/v3/lexer"
 	"github.com/goccmack/gogll/v3/parser"
-	"github.com/goccmack/gogll/v3/parser/bsr"
 )
 
 const src = `package "names"
@@ -15,8 +15,14 @@ qualifiedName : letter {letter|number|'_'} <'.' <letter|number|'_'>> ;
 
 func Test1(t *testing.T) {
 	lex := lexer.New([]rune(src))
-	parser.Parse(lex)
-	g := ast.Build(bsr.GetRoot(), lex)
+	bsr, err := parser.Parse(lex)
+	if err != nil {
+		for _, e := range err {
+			fmt.Printf("error: %#v\n", e.String())
+		}
+		panic(err)
+	}
+	g := ast.Build(bsr.GetRoot(), lex, "test.md")
 
 	New(g)
 }

--- a/lr1/first/first_test.go
+++ b/lr1/first/first_test.go
@@ -1,36 +1,35 @@
 package first
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/goccmack/gogll/ast/rewrite"
-	"github.com/goccmack/gogll/frontend/lexer"
-	"github.com/goccmack/gogll/frontend/parser"
 	"github.com/goccmack/gogll/v3/ast"
-	"github.com/goccmack/gogll/v3/parser/symbols"
+	"github.com/goccmack/gogll/v3/lexer"
+	"github.com/goccmack/gogll/v3/lr1/basicprod"
+	"github.com/goccmack/gogll/v3/parser"
 )
 
 const src = `
-A : B | "a";
-B : ["b"] ;
+package "testx"
+A : B | "a" ;
+B : "b" ; 
 C : B "c" ;
 `
 
 func TestFirst1(t *testing.T) {
-	gram, err := parser.NewParser().Parse(lexer.NewLexer([]byte(src)))
+	lex := lexer.New([]rune(src))
+	bsr, err := parser.Parse(lex)
 	if err != nil {
+		for _, e := range err {
+			fmt.Printf("error: %#v\n", e.String())
+		}
 		panic(err)
 	}
-	g := gram.(*ast.Grammar)
-	basicProds := rewrite.BasicProds(g.SyntaxPart.ProdList)
-	sym, serr := symbols.NewSymbols(g.LexPart, basicProds)
-	if serr != nil {
-		for _, err := range serr {
-			t.Logf("%s", err)
-		}
-	}
-	first := New(sym, basicProds.List())
-	exp := FirstSet{"b", "x", "y"}
+	g := ast.Build(bsr.GetRoot(), lex, "test.md")
+	basicProds := basicprod.Get(g.SyntaxRules)
+	first := New(basicProds)
+	exp := FirstSet{"b"}
 	f := first.FirstString([]string{"B"}, "x", "y")
 	if !f.Equal(exp) {
 		t.Errorf("Expected %s, got %s", exp, f)

--- a/lr1/knuth/states.go
+++ b/lr1/knuth/states.go
@@ -19,7 +19,7 @@ func States(symbols []string, lr0items *items.Items, first *first.First) *states
 			newState := true
 			for _, snum := range symSuccessors[trans.Sym] {
 				if s.List[snum].Equal(trans.State) {
-					st_trans = append(st_trans, states.Transition{trans.Sym, s.List[snum]})
+					st_trans = append(st_trans, states.Transition{Sym: trans.Sym, State: s.List[snum]})
 					newState = false
 				}
 			}

--- a/lr1/pgm/states.go
+++ b/lr1/pgm/states.go
@@ -29,7 +29,7 @@ func States(symbols []string, lr0items *items.Items, first *first.First) *states
 						}
 					}
 
-					st_trans = append(st_trans, states.Transition{trans.Sym, s.List[snum]})
+					st_trans = append(st_trans, states.Transition{Sym: trans.Sym, State: s.List[snum]})
 				}
 			}
 			if !merged {


### PR DESCRIPTION
Fix go vet issues.

Fix test in lr1/firsts_test.go "TestFirst1" to use the new parser api.