### PR TITLE
Render markdown tables correctly

### DIFF
--- a/gogll.md
+++ b/gogll.md
@@ -204,6 +204,7 @@ char_lit : '\'' (not "'" | '\\' any "\\'nrt") '\'' ;
 ```
 `char_lit` is a character literal enclosed in single quotes. A char literal may
 be an escaped character:
+
 |char_lit| Description |
 |---|---|
 `'\''` | single quote
@@ -214,6 +215,7 @@ be an escaped character:
 
 Lexical symbols may be grouped and groups may be optional or repeated.
 For example:
+
 | Bracketed expression | Meaning
 |---|---|
 | `( 𝜶 )` | 𝜶 must occur once


### PR DESCRIPTION
Per gihub markdown guideline a table should have a blank line in front of it

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

> You must include a blank line before your table in order for it to correctly render.

Some client (e.g. Intellij IDEA) do not render the tables correctly.