### PR TITLE
Update installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,7 +138,7 @@ Gogll v3 has a BNF grammar. See [gogll.md](gogll.md)
 
 # Installation
 1. Install Go from [https://golang.org](https://golang.org)
-1. `go get github.com/goccmack/gogll/v3` or 
+1. `go install github.com/goccmack/gogll/v3@latest` or 
 1. Clone this repository and run `go install` in the root of the directory where
 it is installed.
 


### PR DESCRIPTION
Because `go get` is no longer supported outside a module, `go get github.com/goccmack/gogll/v3` no longer works (and implies that the code you're pulling in is a library). `go install github.com/goccmack/gogll/v3@latest` is the comparable command, reflected in this change, which properly installs the latest version of gogll to `$GOPATH/bin` .

Let me know if you have any questions or comments.

Fixes #20