### PR TITLE
fix(LiteralStripEscape): replace escaped "\\n" with '\n' (not '\r')

### DIFF
--- a/gen/golang/token/token.go
+++ b/gen/golang/token/token.go
@@ -156,7 +156,7 @@ func (t *Token) LiteralStripEscape() []rune {
 			case 'r':
 				strip = append(strip, '\r')
 			case 'n':
-				strip = append(strip, '\r')
+				strip = append(strip, '\n')
 			default:
 				strip = append(strip, lit[i])
 			}


### PR DESCRIPTION
Small bug fix. The rune returned from `(*Token).LiteralStripEscape` for escape sequence `"\\n"` should be `'\n'` instead of `'\r'`.